### PR TITLE
Add support to connect to cloud orchestrator using idp auth token

### DIFF
--- a/lib/Orchestrator.js
+++ b/lib/Orchestrator.js
@@ -39,7 +39,7 @@ function validateOptions(options) {
     } else {
         options.path = pathModule.normalize(pathModule.join('/', options.path));
     }
-    if (options.serviceInstanceLogicalName && !options.hostname) {
+    if ((options.serviceInstanceLogicalName || options.cloudOrchestratorAuthToken) && !options.hostname) {
         options.hostname = CLOUD_PLATFORM.platformHostname;
     }
     return options;
@@ -107,6 +107,17 @@ Orchestrator.prototype.switchOrganizationUnitId = function (organizationUnitId) 
 /** @private */
 Orchestrator.prototype._getAccessToken = function () {
     var self = this;
+    /** @type {Array<function(Error=)>} */
+    var loginCallbackList = self._loginCallbackList;
+    self._loginCallbackList = [];
+    
+    if(this._options.cloudOrchestratorAuthToken) {
+        self._credentials = this._options.cloudOrchestratorAuthToken;
+        for (var i = 0; i < loginCallbackList.length; i += 1) {
+            loginCallbackList[i]();
+        }
+        return;
+    }
     var requestOptions = {
         hostname: CLOUD_PLATFORM.hostname,
         isSecure: true,
@@ -127,10 +138,6 @@ Orchestrator.prototype._getAccessToken = function () {
          */
         function (err, response) {
             var i;
-            /** @type {Array<function(Error=)>} */
-            var loginCallbackList = self._loginCallbackList;
-
-            self._loginCallbackList = [];
             if (!err) {
                 self._credentials = response.access_token;
             }
@@ -161,7 +168,7 @@ Orchestrator.prototype._login = function (callback) {
     }
     options = this._options;
     // handle the special case of Cloud Platform login
-    if (options.serviceInstanceLogicalName) {
+    if (options.serviceInstanceLogicalName || options.cloudOrchestratorAuthToken) {
         this._getAccessToken();
         return;
     }
@@ -200,6 +207,7 @@ Orchestrator.prototype._login = function (callback) {
         }
     );
 };
+
 
 /**
  * @param {OrchestratorRestHelperCallback} callback
@@ -446,6 +454,7 @@ Orchestrator.prototype.delete = function (path, callback) {
  * @property {string|undefined} refreshToken
  * @property {string|undefined} serviceInstanceLogicalName
  * @property {string|undefined} clientId
+ * @property {string|undefined} cloudOrchestratorAuthToken
  */
 
 /**


### PR DESCRIPTION
## Description
This PR :
- Adds a new parameter 'cloudOrchestratorAuthToken' (which is the IDP auth token) that can be used when instantiating a cloud orchestrator service object.

## How to test
To instantiate a new service object using idp auth token, we need to set the  'cloudOrchestratorAuthToken' param along with the hostname (optional) and path. 

orchestrator = new Orchestrator(
{cloudOrchestratorAuthToken: 'qwertyuiopasdfghjkllzxcvbnmQWERTYUIOPASDFGHJKzJEJNEKOOJFNNDN',
￼hostname (default : 'account.uipath.com’),
path: 'myAccountLogicalName/myInstanceLogicalName})

For complete details please refer to the following doc which describes supported methods of creating connection to cloud orchestrator using the client : https://uipath.atlassian.net/wiki/spaces/~313910192/pages/1970344709/Cloud-Orchestrator+Authentication+in+uipath-orchestrator+package